### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -25,4 +25,3 @@
 #### Purpose
 
 #### Known Compatibility Issues
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Change
+- removed < ruby 2.1 support newer version of `rubocop` which was pulled as part of security updates (@majormoses)
+
+### Changed
+- updated changelog guidelines location (@majormoses)
+- appeased the cops (@majormoses)
+
 
 ## [1.0.0] 2017-07-14
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/handler-campfire.rb
+++ b/bin/handler-campfire.rb
@@ -32,10 +32,10 @@ class Campfire < Sensu::Handler
   end
 
   def room
-    if settings['campfire']['room_id'].nil? # rubocop:disable Style/GuardClause
-      return campfire.find_room_by_name(settings['campfire']['room'])
+    if settings['campfire']['room_id'].nil?
+      campfire.find_room_by_name(settings['campfire']['room'])
     else
-      return campfire.find_room_by_id(settings['campfire']['room_id'])
+      campfire.find_room_by_id(settings['campfire']['room_id'])
     end
   end
 

--- a/sensu-plugins-campfire.gemspec
+++ b/sensu-plugins-campfire.gemspec
@@ -7,14 +7,14 @@ require_relative 'lib/sensu-plugins-campfire'
 
 # pvt_key = '~/.ssh/gem-private_key.pem'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for campfire'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-campfire'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -26,14 +26,14 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for campfire'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsCampfire::Version::VER_STRING
 
-  s.add_runtime_dependency 'tinder',       '1.10.1'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'tinder',       '1.10.1'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Misc Chanages:
- appeased the cops
- update changelog guidelines location

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Address minor CVE with rubocop

#### Known Compatibility Issues
Removed ruby < 2.1 support.
